### PR TITLE
Move mouse back after clicking

### DIFF
--- a/nexus_autodl.py
+++ b/nexus_autodl.py
@@ -121,9 +121,11 @@ class NexusAutoDL:
             if not box:
                 continue
 
+            initial_position = pyautogui.position()
             match_x, match_y = pyautogui.center(box)
             pyautogui.click(match_x, match_y)
             self._log(f"Matched at ({match_x}, {match_y}).")
+            pyautogui.moveTo(initial_position)
             break
 
         sleep_interval = random.uniform(min_sleep_seconds, max_sleep_seconds)


### PR DESCRIPTION
Makes the mouse cursor jump back to where it was before clicking after the click has finished. If you're using your PC while this is running it makes things slightly less annoying.